### PR TITLE
'configure-eni-routing'

### DIFF
--- a/aws/eni.go
+++ b/aws/eni.go
@@ -108,6 +108,7 @@ func (s *ENI) AttachByTag() error {
 		if err != nil {
 			return microerror.Mask(err)
 		}
+		fmt.Sprintf("Sucesfully configured routing for eth1  for ip %s.\n", *eni.PrivateIpAddress)
 	}
 	return nil
 }

--- a/aws/eni.go
+++ b/aws/eni.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"github.com/giantswarm/aws-attach-etcd-dep/routing"
 	"net"
 	"time"
 
@@ -11,6 +10,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/giantswarm/backoff"
 	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-attach-etcd-dep/routing"
 )
 
 type ENIConfig struct {

--- a/aws/eni.go
+++ b/aws/eni.go
@@ -15,13 +15,12 @@ import (
 )
 
 type ENIConfig struct {
-	AWSInstanceID    string
-	AwsSession       *session.Session
-	ConfigureRouting bool
-	DeviceIndex      int64
-	ForceDetach      bool
-	TagKey           string
-	TagValue         string
+	AWSInstanceID string
+	AwsSession    *session.Session
+	DeviceIndex   int64
+	ForceDetach   bool
+	TagKey        string
+	TagValue      string
 }
 
 type ENI struct {
@@ -52,13 +51,12 @@ func NewENI(config ENIConfig) (*ENI, error) {
 	}
 
 	newENI := &ENI{
-		awsInstanceID:    config.AWSInstanceID,
-		awsSession:       config.AwsSession,
-		deviceIndex:      config.DeviceIndex,
-		configureRouting: config.ConfigureRouting,
-		forceDetach:      config.ForceDetach,
-		tagKey:           config.TagKey,
-		tagValue:         config.TagValue,
+		awsInstanceID: config.AWSInstanceID,
+		awsSession:    config.AwsSession,
+		deviceIndex:   config.DeviceIndex,
+		forceDetach:   config.ForceDetach,
+		tagKey:        config.TagKey,
+		tagValue:      config.TagValue,
 	}
 	return newENI, nil
 }
@@ -93,23 +91,21 @@ func (s *ENI) AttachByTag() error {
 		return microerror.Mask(err)
 	}
 
-	if s.configureRouting {
-		awsEniSubnet, err := s.describeSubnet(ec2Client, *eni.SubnetId)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-		_, ipNet, err := net.ParseCIDR(*awsEniSubnet.CidrBlock)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-		err = routing.ConfigureNetworkRoutingForENI(*eni.PrivateIpAddress, ipNet)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-		fmt.Sprintf("Sucesfully configured routing for eth1  for ip %s.\n", *eni.PrivateIpAddress)
+	awsEniSubnet, err := s.describeSubnet(ec2Client, *eni.SubnetId)
+	if err != nil {
+		return microerror.Mask(err)
 	}
+
+	_, ipNet, err := net.ParseCIDR(*awsEniSubnet.CidrBlock)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = routing.ConfigureNetworkRoutingForENI(*eni.PrivateIpAddress, ipNet)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	fmt.Sprintf("Sucesfully configured routing for eth1  for ip %s.\n", *eni.PrivateIpAddress)
 	return nil
 }
 

--- a/aws/eni.go
+++ b/aws/eni.go
@@ -24,13 +24,12 @@ type ENIConfig struct {
 }
 
 type ENI struct {
-	awsInstanceID    string
-	awsSession       *session.Session
-	configureRouting bool
-	deviceIndex      int64
-	forceDetach      bool
-	tagKey           string
-	tagValue         string
+	awsInstanceID string
+	awsSession    *session.Session
+	deviceIndex   int64
+	forceDetach   bool
+	tagKey        string
+	tagValue      string
 }
 
 func NewENI(config ENIConfig) (*ENI, error) {

--- a/main.go
+++ b/main.go
@@ -14,17 +14,16 @@ import (
 )
 
 type Flag struct {
-	EniConfigureRouting bool
-	EniDeviceIndex      int64
-	EniForceDetach      bool
-	EniTagKey           string
-	EniTagValue         string
-	VolumeDeviceName    string
-	VolumeDeviceFsType  string
-	VolumeDeviceLabel   string
-	VolumeForceDetach   bool
-	VolumeTagKey        string
-	VolumeTagValue      string
+	EniDeviceIndex     int64
+	EniForceDetach     bool
+	EniTagKey          string
+	EniTagValue        string
+	VolumeDeviceName   string
+	VolumeDeviceFsType string
+	VolumeDeviceLabel  string
+	VolumeForceDetach  bool
+	VolumeTagKey       string
+	VolumeTagValue     string
 }
 
 func main() {
@@ -38,7 +37,6 @@ func mainError() error {
 	var err error
 
 	var f Flag
-	flag.BoolVar(&f.EniConfigureRouting, "eni-configure-routing", false, "If set to true, app will use also setup routing for eni to prevent asymetric routing.")
 	flag.Int64Var(&f.EniDeviceIndex, "eni-device-index", 1, "NIC Device index that will be used for attaching the ENI. Cannot be zeroas that is the default NCI that is already attached.")
 	flag.BoolVar(&f.EniForceDetach, "eni-force-detach", false, "If set to true, app will use force-detach if the ENI cannot be detached by normal detach operation..")
 	flag.StringVar(&f.EniTagKey, "eni-tag-key", "aws-attach-by-id", "Tag key that will be used to found the requested ENI in AWS API.")
@@ -74,13 +72,12 @@ func mainError() error {
 	var eni *aws.ENI
 	{
 		eniConfig := aws.ENIConfig{
-			AWSInstanceID:    instanceID,
-			AwsSession:       awsSession,
-			DeviceIndex:      f.EniDeviceIndex,
-			ConfigureRouting: f.EniConfigureRouting,
-			ForceDetach:      f.EniForceDetach,
-			TagKey:           f.EniTagKey,
-			TagValue:         f.EniTagValue,
+			AWSInstanceID: instanceID,
+			AwsSession:    awsSession,
+			DeviceIndex:   f.EniDeviceIndex,
+			ForceDetach:   f.EniForceDetach,
+			TagKey:        f.EniTagKey,
+			TagValue:      f.EniTagValue,
 		}
 
 		eni, err = aws.NewENI(eniConfig)

--- a/main.go
+++ b/main.go
@@ -14,16 +14,17 @@ import (
 )
 
 type Flag struct {
-	EniDeviceIndex     int64
-	EniForceDetach     bool
-	EniTagKey          string
-	EniTagValue        string
-	VolumeDeviceName   string
-	VolumeDeviceFsType string
-	VolumeDeviceLabel  string
-	VolumeForceDetach  bool
-	VolumeTagKey       string
-	VolumeTagValue     string
+	EniConfigureRouting bool
+	EniDeviceIndex      int64
+	EniForceDetach      bool
+	EniTagKey           string
+	EniTagValue         string
+	VolumeDeviceName    string
+	VolumeDeviceFsType  string
+	VolumeDeviceLabel   string
+	VolumeForceDetach   bool
+	VolumeTagKey        string
+	VolumeTagValue      string
 }
 
 func main() {
@@ -37,6 +38,7 @@ func mainError() error {
 	var err error
 
 	var f Flag
+	flag.BoolVar(&f.EniForceDetach, "eni-configure-routing", false, "If set to true, app will use also setup routing for eni to prevent asymetric routing.")
 	flag.Int64Var(&f.EniDeviceIndex, "eni-device-index", 1, "NIC Device index that will be used for attaching the ENI. Cannot be zeroas that is the default NCI that is already attached.")
 	flag.BoolVar(&f.EniForceDetach, "eni-force-detach", false, "If set to true, app will use force-detach if the ENI cannot be detached by normal detach operation..")
 	flag.StringVar(&f.EniTagKey, "eni-tag-key", "aws-attach-by-id", "Tag key that will be used to found the requested ENI in AWS API.")

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ func mainError() error {
 	var err error
 
 	var f Flag
-	flag.BoolVar(&f.EniForceDetach, "eni-configure-routing", false, "If set to true, app will use also setup routing for eni to prevent asymetric routing.")
+	flag.BoolVar(&f.EniConfigureRouting, "eni-configure-routing", false, "If set to true, app will use also setup routing for eni to prevent asymetric routing.")
 	flag.Int64Var(&f.EniDeviceIndex, "eni-device-index", 1, "NIC Device index that will be used for attaching the ENI. Cannot be zeroas that is the default NCI that is already attached.")
 	flag.BoolVar(&f.EniForceDetach, "eni-force-detach", false, "If set to true, app will use force-detach if the ENI cannot be detached by normal detach operation..")
 	flag.StringVar(&f.EniTagKey, "eni-tag-key", "aws-attach-by-id", "Tag key that will be used to found the requested ENI in AWS API.")

--- a/main.go
+++ b/main.go
@@ -74,12 +74,13 @@ func mainError() error {
 	var eni *aws.ENI
 	{
 		eniConfig := aws.ENIConfig{
-			AWSInstanceID: instanceID,
-			AwsSession:    awsSession,
-			DeviceIndex:   f.EniDeviceIndex,
-			ForceDetach:   f.EniForceDetach,
-			TagKey:        f.EniTagKey,
-			TagValue:      f.EniTagValue,
+			AWSInstanceID:    instanceID,
+			AwsSession:       awsSession,
+			DeviceIndex:      f.EniDeviceIndex,
+			ConfigureRouting: f.EniConfigureRouting,
+			ForceDetach:      f.EniForceDetach,
+			TagKey:           f.EniTagKey,
+			TagValue:         f.EniTagValue,
 		}
 
 		eni, err = aws.NewENI(eniConfig)

--- a/routing/error.go
+++ b/routing/error.go
@@ -1,0 +1,7 @@
+package routing
+
+import "github.com/giantswarm/microerror"
+
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}

--- a/routing/network-template.go
+++ b/routing/network-template.go
@@ -13,4 +13,9 @@ From={{.ENIAddress}}/32
 [Route]
 Destination=0.0.0.0/0
 Gateway={{.ENIGateway}}
-Table=2`
+Table=2
+
+[Route]
+Destination={{.ENISubnet}}/{{.ENISubnetSize}}
+Table=2
+Scope=link`

--- a/routing/network-template.go
+++ b/routing/network-template.go
@@ -4,6 +4,9 @@ const networkRoutingTemplate = `# ensure that traffic arriving on eth1 leaves ag
 [Match]
 Name=eth1
 
+[Network]
+DHCP=no
+
 [Address]
 Address={{.ENIAddress}}/{{.ENISubnetSize}}
 Scope=2

--- a/routing/network-template.go
+++ b/routing/network-template.go
@@ -16,6 +16,6 @@ Gateway={{.ENIGateway}}
 Table=2
 
 [Route]
-Destination={{.ENISubnet}}/{{.ENISubnetSize}}
+Destination={{.ENISubnet}}
 Table=2
 Scope=link`

--- a/routing/network-template.go
+++ b/routing/network-template.go
@@ -1,0 +1,16 @@
+package routing
+
+const networkRoutingTemplate = `# ensure that traffic arriving on eth1 leaves again from eth1 to prevent asymetric routing
+[Match]
+Name=eth1
+[Network]
+Address={{.ENIAddress}}/{{.ENISubnetSize}}
+
+[RoutingPolicyRule]
+Table=2
+From={{.ENIAddress}}/32
+
+[Route]
+Destination=0.0.0.0/0
+Gateway={{.ENIGateway}}
+Table=2`

--- a/routing/network-template.go
+++ b/routing/network-template.go
@@ -3,8 +3,10 @@ package routing
 const networkRoutingTemplate = `# ensure that traffic arriving on eth1 leaves again from eth1 to prevent asymetric routing
 [Match]
 Name=eth1
-[Network]
+
+[Address]
 Address={{.ENIAddress}}/{{.ENISubnetSize}}
+Scope=2
 
 [RoutingPolicyRule]
 Table=2
@@ -13,9 +15,4 @@ From={{.ENIAddress}}/32
 [Route]
 Destination=0.0.0.0/0
 Gateway={{.ENIGateway}}
-Table=2
-
-[Route]
-Destination={{.ENISubnet}}
-Table=2
-Scope=link`
+Table=2`

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -20,7 +20,6 @@ type params struct {
 }
 
 func ConfigureNetworkRoutingForENI(eniIP string, eniSubnet *net.IPNet) error {
-
 	p := params{
 		ENIAddress:    eniIP,
 		ENIGateway:    eniGateway(eniSubnet),

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -68,7 +68,7 @@ func restartNetworkd() error {
 	cmdRestart := exec.Command("/usr/bin/systemctl", "restart", "systemd-networkd")
 	out, err = cmdRestart.CombinedOutput()
 	if err != nil {
-		return microerror.Maskf(err, fmt.Sprintf("failed to restart systemd-networkd: %s", out))
+		return microerror.Maskf(executionFailedError, fmt.Sprintf("failed to restart systemd-networkd with error %#q and output %#q", err, out))
 	}
 
 	return nil

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -62,7 +62,7 @@ func restartNetworkd() error {
 	cmdReload := exec.Command("/usr/bin/systemctl", "daemon-reload")
 	out, err := cmdReload.CombinedOutput()
 	if err != nil {
-		return microerror.Maskf(err, fmt.Sprintf("failed to reload daemon for systemd: %s", out))
+		return microerror.Maskf(executionFailedError, fmt.Sprintf("failed to reload daemon for systemd with error %#q and output %#q", err, out))
 	}
 
 	cmdRestart := exec.Command("/usr/bin/systemctl", "restart", "systemd-networkd")

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -53,8 +53,7 @@ func renderRoutingNetworkdFile(p params) error {
 
 func eniGateway(ipNet *net.IPNet) string {
 	// https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Subnets.html
-	gatewayAddressIP := dupIP(ipNet.IP)
-	gatewayAddressIP.To4()
+	gatewayAddressIP := cloneIP(ipNet.IP)
 	gatewayAddressIP[3] += 1
 
 	return gatewayAddressIP.String()
@@ -66,8 +65,8 @@ func eniSubnetSize(ipNet *net.IPNet) int {
 	return subnetSize
 }
 
-func dupIP(ip net.IP) net.IP {
-	dup := make(net.IP, len(ip))
-	copy(dup, ip)
-	return dup
+func cloneIP(ip net.IP) net.IP {
+	c := make(net.IP, len(ip))
+	copy(c, ip)
+	return c
 }

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
-	"os"
 	"os/exec"
 	"text/template"
 
@@ -51,7 +50,7 @@ func renderRoutingNetworkdFile(params Params) error {
 		return microerror.Mask(err)
 	}
 
-	err = ioutil.WriteFile(eth1FileName, buff.Bytes(), os.ModeAppend)
+	err = ioutil.WriteFile(eth1FileName, buff.Bytes(), 0644)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -61,15 +60,15 @@ func renderRoutingNetworkdFile(params Params) error {
 
 func restartNetworkd() error {
 	cmdReload := exec.Command("/usr/bin/systemctl", "daemon-reload")
-	err := cmdReload.Run()
+	out, err := cmdReload.CombinedOutput()
 	if err != nil {
-		return microerror.Maskf(err, fmt.Sprintf("failed to reload daemon for systemd: %s", err))
+		return microerror.Maskf(err, fmt.Sprintf("failed to reload daemon for systemd: %s", out))
 	}
 
 	cmdRestart := exec.Command("/usr/bin/systemctl", "restart", "systemd-networkd")
-	err = cmdRestart.Run()
+	out, err = cmdRestart.CombinedOutput()
 	if err != nil {
-		return microerror.Maskf(err, fmt.Sprintf("failed to restart systemd-networkd: %s", err))
+		return microerror.Maskf(err, fmt.Sprintf("failed to restart systemd-networkd: %s", out))
 	}
 
 	return nil

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -1,0 +1,97 @@
+package routing
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"os/exec"
+	"text/template"
+
+	"github.com/giantswarm/microerror"
+)
+
+const (
+	eth1FileName = "/etc/systemd/network/10-eth1.network"
+)
+
+type Params struct {
+	ENIAddress    string
+	ENIGateway    string
+	ENISubnetSize int
+}
+
+func ConfigureNetworkRoutingForENI(eniIP string, eniSubnet *net.IPNet) error {
+
+	params := Params{
+		ENIAddress:    eniIP,
+		ENIGateway:    eniGateway(eniSubnet),
+		ENISubnetSize: eniSubnetSize(eniSubnet),
+	}
+
+	err := renderRoutingNetworkdFile(params)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = restartNetworkd()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	return nil
+}
+
+func renderRoutingNetworkdFile(params Params) error {
+	var buff bytes.Buffer
+	t := template.Must(template.New("routing").Parse(networkRoutingTemplate))
+
+	err := t.Execute(&buff, params)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = ioutil.WriteFile(eth1FileName, buff.Bytes(), os.ModeAppend)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func restartNetworkd() error {
+	cmdReload := exec.Command("/usr/bin/systemctl", "daemon-reload")
+	err := cmdReload.Run()
+	if err != nil {
+		return microerror.Maskf(err, fmt.Sprintf("failed to reload daemon for systemd: %s", err))
+	}
+
+	cmdRestart := exec.Command("/usr/bin/systemctl", "restart", "systemd-networkd")
+	err = cmdRestart.Run()
+	if err != nil {
+		return microerror.Maskf(err, fmt.Sprintf("failed to restart systemd-networkd: %s", err))
+	}
+
+	return nil
+}
+
+func eniGateway(ipNet *net.IPNet) string {
+	// https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Subnets.html
+	gatewayAddressIP := dupIP(ipNet.IP)
+	gatewayAddressIP.To4()
+	gatewayAddressIP[3] += 1
+
+	return gatewayAddressIP.String()
+}
+
+func eniSubnetSize(ipNet *net.IPNet) int {
+	subnetSize, _ := ipNet.Mask.Size()
+
+	return subnetSize
+}
+
+func dupIP(ip net.IP) net.IP {
+	dup := make(net.IP, len(ip))
+	copy(dup, ip)
+	return dup
+}

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -16,6 +16,7 @@ const (
 type params struct {
 	ENIAddress    string
 	ENIGateway    string
+	ENISubnet     string
 	ENISubnetSize int
 }
 
@@ -23,6 +24,7 @@ func ConfigureNetworkRoutingForENI(eniIP string, eniSubnet *net.IPNet) error {
 	p := params{
 		ENIAddress:    eniIP,
 		ENIGateway:    eniGateway(eniSubnet),
+		ENISubnet:     eniSubnet.String(),
 		ENISubnetSize: eniSubnetSize(eniSubnet),
 	}
 

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -2,10 +2,8 @@ package routing
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"net"
-	"os/exec"
 	"text/template"
 
 	"github.com/giantswarm/microerror"
@@ -34,10 +32,6 @@ func ConfigureNetworkRoutingForENI(eniIP string, eniSubnet *net.IPNet) error {
 		return microerror.Mask(err)
 	}
 
-	err = restartNetworkd()
-	if err != nil {
-		return microerror.Mask(err)
-	}
 	return nil
 }
 
@@ -53,22 +47,6 @@ func renderRoutingNetworkdFile(p params) error {
 	err = ioutil.WriteFile(eth1FileName, buff.Bytes(), 0644)
 	if err != nil {
 		return microerror.Mask(err)
-	}
-
-	return nil
-}
-
-func restartNetworkd() error {
-	cmdReload := exec.Command("/usr/bin/systemctl", "daemon-reload")
-	out, err := cmdReload.CombinedOutput()
-	if err != nil {
-		return microerror.Maskf(executionFailedError, fmt.Sprintf("failed to reload daemon for systemd with error %#q and output %#q", err, out))
-	}
-
-	cmdRestart := exec.Command("/usr/bin/systemctl", "restart", "systemd-networkd")
-	out, err = cmdRestart.CombinedOutput()
-	if err != nil {
-		return microerror.Maskf(executionFailedError, fmt.Sprintf("failed to restart systemd-networkd with error %#q and output %#q", err, out))
 	}
 
 	return nil


### PR DESCRIPTION
to fix the PM https://github.com/giantswarm/giantswarm/issues/10474

removing the static IP from the ENI, so that means we cannot render the eth1 routing file in the aws-operator and put it in the ignition(we don't know the IP of the ENI during that time)  and instead we render it when attaching the ENI

Not much new things just reducing some complexity in aws-operator and putting it here more simplified

Should be backward compatible