### PR TITLE
Increase wait time for disk and ENI attachment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Increase wait time for disk and ENI attachment.
+
 ## [0.2.0] - 2021-09-29
 
 ## [0.1.0] - 2020-07-07

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CircleCI](https://circleci.com/gh/giantswarm/aws-attach-ebs-by-tag.svg?style=shield&circle-token=cbabd7d13186f190fca813db4f0c732b026f5f6c)](https://circleci.com/gh/giantswarm/aws-attach-ebs-by-tag)
+[![CircleCI](https://circleci.com/gh/giantswarm/aws-attach-etcd-dep/tree/master.svg?style=svg)](https://circleci.com/gh/giantswarm/aws-attach-etcd-dep/tree/master)
 
 # aws attach etcd dependencies
 

--- a/aws/eni.go
+++ b/aws/eni.go
@@ -165,7 +165,7 @@ func (s *ENI) attach(ec2Client *ec2.EC2, instanceID string, eniID string) error 
 		}
 
 		if *eni.Status != ec2.NetworkInterfaceStatusInUse && *eni.Attachment.InstanceId == instanceID {
-			fmt.Printf("Volume state is %q, expecting %q, retrying in %ds.\n", *eni.Status, ec2.NetworkInterfaceStatusInUse, retryInterval/time.Second)
+			fmt.Printf("ENI state is %q, expecting %q, retrying in %ds.\n", *eni.Status, ec2.NetworkInterfaceStatusInUse, retryInterval/time.Second)
 			return microerror.Maskf(executionFailedError, "ENI not attached")
 		}
 		return nil
@@ -191,7 +191,7 @@ func (s *ENI) detach(ec2Client *ec2.EC2, eni *ec2.NetworkInterface) error {
 		}
 
 		if *eni.Status != ec2.NetworkInterfaceStatusAvailable {
-			fmt.Printf("Volume state is %q, expecting %q, retrying in %s.\n", *eni.Status, ec2.NetworkInterfaceStatusAvailable, retryInterval)
+			fmt.Printf("ENI state is %q, expecting %q, retrying in %s.\n", *eni.Status, ec2.NetworkInterfaceStatusAvailable, retryInterval)
 			return microerror.Maskf(executionFailedError, "ENI not detached")
 		}
 		return nil

--- a/aws/key.go
+++ b/aws/key.go
@@ -13,8 +13,8 @@ const (
 	maxRetries    = 240
 	retryInterval = time.Second * 15
 
-	// wait for detach for 10 mins
-	waitAutoDetachMaxRetries = 40
+	// wait for detach for 20 mins
+	waitAutoDetachMaxRetries = 80
 )
 
 func tagKey(input string) *string {

--- a/aws/key.go
+++ b/aws/key.go
@@ -13,8 +13,8 @@ const (
 	maxRetries    = 240
 	retryInterval = time.Second * 15
 
-	// wait for detach for 20 mins
-	waitAutoDetachMaxRetries = 80
+	// wait for detach for 30 mins
+	waitAutoDetachMaxRetries = 120
 )
 
 func tagKey(input string) *string {


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/815

Due to termination handler, it takes longer than before for the old masters to be terminated.
This might hit a timeout while waiting for etcd deps to be attached and lead to a failure in provisioning.

This PR increases the timeout to avoid such scenario